### PR TITLE
Redo spray injection

### DIFF
--- a/Exec/SprayTests/PeleC/Multijet/SprayParticlesInitInsert.cpp
+++ b/Exec/SprayTests/PeleC/Multijet/SprayParticlesInitInsert.cpp
@@ -39,17 +39,20 @@ SprayParticleContainer::injectParticles(
     m_injectVel = jet_vel;
     jet_vel = max_vel;
   }
+  int curProc = amrex::ParallelDescripter::MyProc();
   amrex::Real part_dia = prob_parm.part_mean_dia;
   amrex::Real part_stdev = prob_parm.part_stdev_dia;
   LogNormDist log_dist(part_dia, part_stdev);
-  amrex::Real jet_angle = 0.;
   const int norm_dir = 1;
+  amrex::RealVect jet_norm(amrex::RealVect::TheZeroVector());
+  jet_norm[norm_dir] = 1.;
   for (int jindx = 0; jindx < prob_parm.num_jets; ++jindx) {
-    amrex::RealVect cur_jet_cent = prob_parm.jet_cents[jindx];
-    sprayInjection<LogNormDist>(
-      log_dist, cur_jet_cent, jet_dia, prob_parm.part_temp, mass_flow_rate,
-      jet_vel, prob_parm.spray_angle, dt, prob_parm.Y_jet.data(), lev,
-      jet_angle, 0., 360., norm_dir);
+    if (curProc == jindx) {
+      amrex::RealVect cur_jet_cent = prob_parm.jet_cents[jindx];
+      sprayInjection<LogNormDist>(
+        log_dist, cur_jet_cent, jet_norm, jet_dia, prob_parm.part_temp, mass_flow_rate,
+        jet_vel, prob_parm.spray_angle, dt, prob_parm.Y_jet.data(), lev, curProc);
+    }
   }
   // Redistribute is done outside of this function
   return true;

--- a/Exec/SprayTests/PeleC/Multijet/first-input
+++ b/Exec/SprayTests/PeleC/Multijet/first-input
@@ -126,5 +126,4 @@ prob.jet_start_time = 0.
 prob.jet_end_time = 1.54E-3
 prob.jet_vel = 6.E4
 # This divides the cells into smaller squares for injecting particles
-prob.jet_dx_mod = 42.
 prob.mass_flow_rate = 2.3

--- a/Exec/SprayTests/PeleC/jet_spray/SprayParticlesInitInsert.cpp
+++ b/Exec/SprayTests/PeleC/jet_spray/SprayParticlesInitInsert.cpp
@@ -67,12 +67,13 @@ SprayParticleContainer::injectParticles(
   amrex::Real part_dia = prob_parm.part_mean_dia;
   amrex::Real part_stdev = prob_parm.part_stdev_dia;
   LogNormDist log_dist(part_dia, part_stdev);
-  amrex::Real jet_angle = 0.;
   const int norm_dir = 1;
+  amrex::RealVect jet_norm(amrex::RealVect::TheZeroVector());
+  jet_norm[norm_dir] = 1.;
   sprayInjection<LogNormDist>(
-    log_dist, prob_parm.jet_cent, jet_dia, prob_parm.part_temp, mass_flow_rate,
-    jet_vel, prob_parm.spray_angle, dt, prob_parm.Y_jet.data(), lev, jet_angle,
-    0., 360., norm_dir);
+    log_dist, prob_parm.jet_cent, jet_norm, jet_dia, prob_parm.part_temp,
+    mass_flow_rate, jet_vel, prob_parm.spray_angle, dt, prob_parm.Y_jet.data(),
+    lev);
   // Redistribute is done outside of this function
   return true;
 }

--- a/Exec/SprayTests/PeleC/jet_spray/inputs-2d
+++ b/Exec/SprayTests/PeleC/jet_spray/inputs-2d
@@ -113,7 +113,6 @@ prob.init_O2 = 0.
 # Jet properties
 prob.jet_dia = 9.E-3
 prob.spray_angle_deg = 21.
-prob.jet_dx_mod = 50.
 
 # Properties of injected particles
 prob.part_temp = 363.

--- a/Exec/SprayTests/PeleLM/Multijet/SprayParticlesInitInsert.cpp
+++ b/Exec/SprayTests/PeleLM/Multijet/SprayParticlesInitInsert.cpp
@@ -63,13 +63,14 @@ SprayParticleContainer::injectParticles(
   amrex::Real part_dia = prob_parm.part_mean_dia;
   amrex::Real part_stdev = prob_parm.part_stdev_dia;
   LogNormDist log_dist(part_dia, part_stdev);
+  amrex::RealVect jet_norm(amrex::RealVect::TheZeroVector());
   int norm_dir = 1;
+  jet_norm[norm_dir] = 1.;
   for (int jindx = 0; jindx < prob_parm.num_jets; ++jindx) {
     amrex::RealVect cur_jet_cent = jet_cents[jindx];
     sprayInjection<LogNormDist>(
-      log_dist, jet_dia, part_temp, mass_flow_rate, jet_vel,
-      prob_parm.spray_angle, dt, prob_parm.Y_jet.data(), lev, 0., 0., 360.,
-      norm_dir);
+      log_dist, jet_dia, jet_norm, part_temp, mass_flow_rate, jet_vel,
+      prob_parm.spray_angle, dt, prob_parm.Y_jet.data(), lev);
   }
   // Redistribute is done outside of this function
   return true;

--- a/Exec/SprayTests/PeleLM/Multijet/first-input
+++ b/Exec/SprayTests/PeleLM/Multijet/first-input
@@ -57,7 +57,6 @@ prob.jets_per_dir = 2 1 2
 prob.jet_start_time = 0.
 prob.jet_end_time = 2.
 prob.jet_vel = 60.
-prob.jet_dx_mod = 42.
 prob.mass_flow_rate = 2.3E-5
 
 #--------------------SPRAY PARTICLE DATA-----------------------

--- a/Exec/SprayTests/PeleLM/Multijet/pelelm_prob.cpp
+++ b/Exec/SprayTests/PeleLM/Multijet/pelelm_prob.cpp
@@ -21,7 +21,6 @@ amrex_probinit(
   pp.query("jet_start_time", PeleLM::prob_parm->jet_start_time);
   pp.query("jet_end_time", PeleLM::prob_parm->jet_end_time);
   // The cells are divided by this value when prescribing the jet inlet
-  pp.query("jet_dx_mod", PeleLM::prob_parm->jet_dx_mod);
   pp.get("jet_dia", PeleLM::prob_parm->jet_dia);
   pp.get("part_mean_dia", PeleLM::prob_parm->part_mean_dia);
   pp.query("part_stdev_dia", PeleLM::prob_parm->part_stdev_dia);

--- a/Exec/SprayTests/PeleLM/Multijet/pelelm_prob_parm.H
+++ b/Exec/SprayTests/PeleLM/Multijet/pelelm_prob_parm.H
@@ -22,7 +22,6 @@ struct ProbParm
   amrex::Real jet_start_time = 0.;
   amrex::Real jet_end_time = 10000.;
   amrex::Real spray_angle = 20.;
-  amrex::Real jet_dx_mod = 50.;
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> Y_jet = {{0.0}};
   amrex::GpuArray<int, AMREX_SPACEDIM> jets_per_dir = {{0}};
   unsigned int num_jets = 0;

--- a/Exec/SprayTests/PeleLM/marco_spray/SprayParticlesInitInsert.cpp
+++ b/Exec/SprayTests/PeleLM/marco_spray/SprayParticlesInitInsert.cpp
@@ -40,9 +40,10 @@ SprayParticleContainer::injectParticles(
   }
   amrex::Real part_dia = prob_parm.part_mean_dia;
   amrex::Real part_stdev = prob_parm.part_stdev_dia;
+  amrex::RealVect jet_norm(0., 0., 1.);
   LogNormDist log_dist(part_dia, part_stdev);
   sprayInjection<LogNormDist>(
-    log_dist, prob_parm.jet_cent, jet_dia, part_temp, mass_flow_rate, jet_vel,
+    log_dist, prob_parm.jet_cent, jet_norm, jet_dia, part_temp, mass_flow_rate, jet_vel,
     prob_parm.spray_angle, dt, prob_parm.Y_jet.data(), lev);
   // Redistribute is done outside of this function
   return true;

--- a/Exec/SprayTests/PeleLM/marco_spray/inputs.3d.cuda
+++ b/Exec/SprayTests/PeleLM/marco_spray/inputs.3d.cuda
@@ -60,7 +60,6 @@ prob.jets_per_dir = 1
 prob.jet_start_time = 0.
 prob.jet_end_time = .5E-3
 prob.jet_vel = 30.
-prob.jet_dx_mod = 42.
 #prob.mass_flow_rate = 2.0349e-5
 prob.mass_flow_rate = 1.0174e-7
 #prob.jet_end_time = 0.00052

--- a/Exec/SprayTests/PeleLM/marco_spray/pelelm_prob.cpp
+++ b/Exec/SprayTests/PeleLM/marco_spray/pelelm_prob.cpp
@@ -16,7 +16,6 @@ extern "C" {
 
       	pp.query("jet_vel", PeleLM::prob_parm->jet_vel);
         // The cells are divided by this value when prescribing the jet inlet
-        pp.query("jet_dx_mod", PeleLM::prob_parm->jet_dx_mod);
         pp.get("jet_dia", PeleLM::prob_parm->jet_dia);
         pp.get("part_mean_dia", PeleLM::prob_parm->part_mean_dia);
         pp.query("part_stdev_dia", PeleLM::prob_parm->part_stdev_dia);

--- a/Exec/SprayTests/PeleLM/marco_spray/pelelm_prob_parm.H
+++ b/Exec/SprayTests/PeleLM/marco_spray/pelelm_prob_parm.H
@@ -22,7 +22,6 @@ struct ProbParm
     amrex::Real jet_start_time = 0.;
     amrex::Real jet_end_time = 10000.;
     amrex::Real spray_angle = 0.42;
-    amrex::Real jet_dx_mod = 50.;
     amrex::Real gas_jet_vel = 50.;
     amrex::Real gas_jet_dia = 1.E-5;
     amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> Y_jet = {{0.0}};

--- a/Exec/SprayTests/PeleLM/spray_flame/SprayParticlesInitInsert.cpp
+++ b/Exec/SprayTests/PeleLM/spray_flame/SprayParticlesInitInsert.cpp
@@ -42,8 +42,8 @@ SprayParticleContainer::injectParticles(
   amrex::Real part_stdev = prob_parm.part_stdev_dia;
   LogNormDist log_dist(part_dia, part_stdev);
   sprayInjection<LogNormDist>(
-    log_dist, prob_parm.jet_cent, jet_dia, part_temp, mass_flow_rate, jet_vel,
-    prob_parm.spray_angle, dt, prob_parm.Y_jet.data(), lev);
+    log_dist, prob_parm.jet_cent, prob_parm.jet_norm, jet_dia, part_temp, mass_flow_rate, jet_vel,
+    prob_parm.spread_angle, dt, prob_parm.Y_jet.data(), lev);
   // Redistribute is done outside of this function
   return true;
 }

--- a/Exec/SprayTests/PeleLM/spray_flame/inputs.3d
+++ b/Exec/SprayTests/PeleLM/spray_flame/inputs.3d
@@ -58,7 +58,6 @@ prob.spray_angle_deg = 21.
 prob.jet_start_time = 0.
 prob.jet_end_time = 0.5E-3
 prob.jet_vel = 30.
-prob.jet_dx_mod = 42.
 prob.mass_flow_rate = 2.0349e-5
 
 #--------------------SPRAY PARTICLE DATA-----------------------
@@ -116,9 +115,6 @@ ns.num_mac_sync_iter = 2               # Number of mac_sync iterations
 peleLM.chem_integrator = "ReactorCvode"
 peleLM.use_typ_vals_chem = 1          # Use species/temp typical values in CVODE
 cvode.solve_type = GMRES              # CVODE Linear solve type (for Newton direction) 
-ode.analytical_jacobian = 0           # Provide analytical jacobian (from Fuego) ?
-ode.atol = 1.E-8
-ode.rtol = 1.E-6
 
 # ------------------  INPUTS TO ACTIVE CONTROL  ----------------------
 active_control.on = 0                  # Use AC ?

--- a/Exec/SprayTests/PeleLM/spray_flame/pelelm_prob.cpp
+++ b/Exec/SprayTests/PeleLM/spray_flame/pelelm_prob.cpp
@@ -19,13 +19,12 @@ amrex_probinit(
 
   pp.query("jet_vel", PeleLM::prob_parm->jet_vel);
   // The cells are divided by this value when prescribing the jet inlet
-  pp.query("jet_dx_mod", PeleLM::prob_parm->jet_dx_mod);
   pp.get("jet_dia", PeleLM::prob_parm->jet_dia);
   pp.get("part_mean_dia", PeleLM::prob_parm->part_mean_dia);
   pp.query("part_stdev_dia", PeleLM::prob_parm->part_stdev_dia);
   pp.get("part_temp", PeleLM::prob_parm->part_temp);
   pp.query("mass_flow_rate", PeleLM::prob_parm->mass_flow_rate);
-  pp.get("spray_angle_deg", PeleLM::prob_parm->spray_angle);
+  pp.get("spray_angle_deg", PeleLM::prob_parm->spread_angle);
   std::vector<amrex::Real> in_Y_jet(SPRAY_FUEL_NUM, 0.);
   in_Y_jet[0] = 1.;
   pp.queryarr("jet_mass_fracs", in_Y_jet);
@@ -41,8 +40,10 @@ amrex_probinit(
   PeleLM::prob_parm->spray_angle *= M_PI / 180.;
   for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
     PeleLM::prob_parm->jet_cent[dir] = problo[dir] + 0.5 * (probhi[dir] - problo[dir]);
+    PeleLM::prob_parm->jet_norm[dir] = 0.;
   }
   int lowD = AMREX_SPACEDIM - 1;
   PeleLM::prob_parm->jet_cent[lowD] = problo[lowD];
+  PeleLM::prob_parm->jet_norm[lowD] = 1.;
 }
 }

--- a/Exec/SprayTests/PeleLM/spray_flame/pelelm_prob_parm.H
+++ b/Exec/SprayTests/PeleLM/spray_flame/pelelm_prob_parm.H
@@ -18,12 +18,12 @@ struct ProbParm
   amrex::Real part_mean_dia = 1.E-6;
   amrex::Real part_stdev_dia = 0.;
   amrex::Real mass_flow_rate = 2.3E-3;
+  amrex::Real spread_angle = 20.;
   amrex::Real part_temp = 300.;
   amrex::Real jet_start_time = 0.;
   amrex::Real jet_end_time = 10000.;
-  amrex::Real spray_angle = 20.;
-  amrex::Real jet_dx_mod = 50.;
   amrex::GpuArray<amrex::Real, SPRAY_FUEL_NUM> Y_jet = {{0.0}};
   amrex::RealVect jet_cent;
+  amrex::RealVect jet_norm;
 };
 #endif

--- a/Exec/SprayTests/PeleLMeX/marco_spray/SprayParticlesInitInsert.cpp
+++ b/Exec/SprayTests/PeleLMeX/marco_spray/SprayParticlesInitInsert.cpp
@@ -34,9 +34,10 @@ SprayParticleContainer::injectParticles(
     m_injectVel = jet_vel;
     jet_vel = max_vel;
   }
+  amrex::RealVect jet_norm(0., 0., 1.);
   LogNormDist log_dist(prob_parm.part_mean_dia, prob_parm.part_stdev_dia);
   sprayInjection<LogNormDist>(
-    log_dist, prob_parm.jet_cent, prob_parm.jet_dia, prob_parm.part_temp,
+    log_dist, prob_parm.jet_cent, jet_norm, prob_parm.jet_dia, prob_parm.part_temp,
     prob_parm.mass_flow_rate, jet_vel, prob_parm.spray_angle, dt,
     prob_parm.Y_jet.data(), lev);
   // Redistribute is done outside of this function

--- a/Exec/SprayTests/PeleLMeX/spray_flame/SprayParticlesInitInsert.cpp
+++ b/Exec/SprayTests/PeleLMeX/spray_flame/SprayParticlesInitInsert.cpp
@@ -37,17 +37,15 @@ SprayParticleContainer::injectParticles(
   if (prob_parm.part_stdev_dia >= 0.) {
     LogNormDist log_dist(prob_parm.part_mean_dia, prob_parm.part_stdev_dia);
     sprayInjection<LogNormDist>(
-      log_dist, prob_parm.jet_cent, prob_parm.jet_dia, prob_parm.part_temp,
+      log_dist, prob_parm.jet_cent, prob_parm.jet_norm, prob_parm.jet_dia, prob_parm.part_temp,
       prob_parm.mass_flow_rate, jet_vel, prob_parm.spread_angle, dt,
-      prob_parm.Y_jet.data(), lev, prob_parm.jet_angle, prob_parm.jet_azi_lo,
-      prob_parm.jet_azi_hi);
+      prob_parm.Y_jet.data(), lev, prob_parm.num_inj_procs);
   } else {
     WeibullDist w_dist(prob_parm.part_mean_dia, prob_parm.part_weibull_k);
     sprayInjection<WeibullDist>(
-      w_dist, prob_parm.jet_cent, prob_parm.jet_dia, prob_parm.part_temp,
+      w_dist, prob_parm.jet_cent, prob_parm.jet_norm, prob_parm.jet_dia, prob_parm.part_temp,
       prob_parm.mass_flow_rate, jet_vel, prob_parm.spread_angle, dt,
-      prob_parm.Y_jet.data(), lev, prob_parm.jet_angle, prob_parm.jet_azi_lo,
-      prob_parm.jet_azi_hi);
+      prob_parm.Y_jet.data(), lev, prob_parm.num_inj_procs);
   }
   // Redistribute is done outside of this function
   return true;

--- a/Exec/SprayTests/PeleLMeX/spray_flame/input.2d
+++ b/Exec/SprayTests/PeleLMeX/spray_flame/input.2d
@@ -28,7 +28,8 @@ prob.P_mean = 101325.
 prob.T_init = 900.
 
 # Jet parameters
-prob.jet_cent = 0. 0. 0.
+prob.jet_cent = 0. 0.
+prob.jet_norm = 0. 1.
 prob.part_temp  = 300.
 # NC10H22
 prob.Y_jet  = 1.
@@ -39,13 +40,8 @@ prob.part_mean_dia = 4.E-5
 prob.part_stdev_dia = 0.
 # Jet properties
 prob.jet_dia = 0.004
-# The polar angle in degrees relative to the Z axis
-prob.jet_angle = 30.
 # The spreading angle in degrees
 prob.spread_angle = 21.
-# The bounds on the azimuthal angle in degrees
-prob.jet_azi_lo = 0.
-prob.jet_azi_hi = 360.
 # Magnitude of the jet velocity
 prob.jet_vel = 30.
 prob.mass_flow_rate = 1.E-3

--- a/Exec/SprayTests/PeleLMeX/spray_flame/input.3d
+++ b/Exec/SprayTests/PeleLMeX/spray_flame/input.3d
@@ -1,7 +1,7 @@
 #----------------------DOMAIN DEFINITION------------------------
 geometry.is_periodic = 0 0 0
 geometry.coord_sys   = 0                  # 0 => cart, 1 => RZ
-geometry.prob_lo     = -0.027 0.027 0.
+geometry.prob_lo     = -0.027 -0.027 0.
 geometry.prob_hi     =  0.027 0.027 0.054
 
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
@@ -29,7 +29,8 @@ prob.T_init = 900.
 prob.vel_init = 0. 0. 0.
 
 # Jet parameters
-prob.jet_cent = 0. 0. 0.
+prob.jet_cent = 0.001 0.001 0.004
+prob.jet_norm = 0.5 -0.5 0.707106781186548
 prob.part_temp  = 300.
 # NC10H22
 prob.Y_jet  = 1.

--- a/Exec/SprayTests/PeleLMeX/spray_flame/pelelm_prob.cpp
+++ b/Exec/SprayTests/PeleLMeX/spray_flame/pelelm_prob.cpp
@@ -11,9 +11,15 @@ void PeleLM::readProbParm()
   pp.get("jet_vel", PeleLM::prob_parm->jet_vel);
   std::vector<amrex::Real> jcent(AMREX_SPACEDIM);
   pp.getarr("jet_cent", jcent);
+  std::vector<amrex::Real> jnorm(AMREX_SPACEDIM);
+  pp.getarr("jet_norm", jnorm);
   for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
     PeleLM::prob_parm->jet_cent[dir] = jcent[dir];
+    PeleLM::prob_parm->jet_norm[dir] = jnorm[dir];
   }
+  PeleLM::prob_parm->num_inj_procs = 1;
+  // Number of processors to do the injection
+  pp.query("num_inj_procs", PeleLM::prob_parm->num_inj_procs);
   // The cells are divided by this value when prescribing the jet inlet
   pp.get("jet_dia", PeleLM::prob_parm->jet_dia);
   pp.get("part_mean_dia", PeleLM::prob_parm->part_mean_dia);
@@ -31,9 +37,6 @@ void PeleLM::readProbParm()
   // All angles must be in degrees
   // This is the spreading angle
   pp.get("spread_angle", PeleLM::prob_parm->spread_angle);
-  pp.query("jet_angle", PeleLM::prob_parm->jet_angle);
-  pp.query("jet_azi_lo", PeleLM::prob_parm->jet_azi_lo);
-  pp.query("jet_azi_hi", PeleLM::prob_parm->jet_azi_hi);
   std::vector<amrex::Real> in_Y_jet(SPRAY_FUEL_NUM, 0.);
   in_Y_jet[0] = 1.;
   pp.queryarr("Y_jet", in_Y_jet);
@@ -47,7 +50,4 @@ void PeleLM::readProbParm()
   }
   // Convert to radians
   PeleLM::prob_parm->spread_angle *= M_PI / 180.;
-  PeleLM::prob_parm->jet_azi_lo *= M_PI / 180.;
-  PeleLM::prob_parm->jet_azi_hi *= M_PI / 180.;
-  PeleLM::prob_parm->jet_angle *= M_PI / 180.;
 }

--- a/Exec/SprayTests/PeleLMeX/spray_flame/pelelm_prob_parm.H
+++ b/Exec/SprayTests/PeleLMeX/spray_flame/pelelm_prob_parm.H
@@ -20,19 +20,15 @@ struct ProbParm
   amrex::Real jet_vel = 50.;
   // This is the spread of the jet
   amrex::Real spread_angle = 20.;
+  int num_inj_procs = 1;
 
   amrex::Real part_mean_dia = 1.E-6;
   amrex::Real part_stdev_dia = -1.;
   amrex::Real part_weibull_k = 3.;
   amrex::Real mass_flow_rate = 2.3E-3;
   amrex::Real part_temp = 300.;
-  // This is the polar angle of the jet from the Z axis
-  // 0 is perpendicular to the lower jet boundary
-  amrex::Real jet_angle = 0.;
-  // These are bounds on the azimuthal angle
-  amrex::Real jet_azi_lo = 0.;
-  amrex::Real jet_azi_hi = 360.;
   // Center of the jet
   amrex::RealVect jet_cent;
+  amrex::RealVect jet_norm;
 };
 #endif

--- a/Source/PP_Spray/SprayInjectTemplate.H
+++ b/Source/PP_Spray/SprayInjectTemplate.H
@@ -114,7 +114,7 @@ SprayParticleContainer::sprayInjection(
 #else
   amrex::Real theta_1 = std::atan2(jet_norm[1], jet_norm[0]) + M_PI / 2.;
 #endif
-  amrex::real mass_perc = inject_mass / injProcs;
+  amrex::Real mass_perc = inject_mass / injProcs;
   while (cur_mass < mass_perc) {
     // Pick random percentage from 0 to 1
     amrex::Real radp = amrex::Random();

--- a/Source/PP_Spray/SprayInjectTemplate.H
+++ b/Source/PP_Spray/SprayInjectTemplate.H
@@ -3,61 +3,7 @@
 #include "SprayParticles.H"
 
 // This provides a function to be called in the SprayParticlesInitInsert.cpp
-// file Included is a standard jet injection calls
-
-amrex::Real
-jetOverlapArea(
-  const amrex::Real testdx,
-  const amrex::RealVect xloJ,
-  const amrex::RealVect xhiJ,
-  const amrex::RealVect jet_cent,
-  const amrex::Real jr2,
-#if AMREX_SPACEDIM == 3
-  amrex::Real& loy,
-  amrex::Real& hiy,
-#endif
-  amrex::Real& lox,
-  amrex::Real& hix)
-{
-  // This is how much we reduce x to test for the area of the jet
-  // This helps if the jet size is smaller than cell size
-  amrex::Real cur_jet_area = 0.;
-  amrex::Real testdx2 = testdx * testdx;
-  amrex::Real curx = xloJ[0];
-  hix = xloJ[0];
-  lox = xhiJ[0];
-  // Loop over each cell and check how much overlap there is with the jet
-#if AMREX_SPACEDIM == 3
-  hiy = xloJ[1];
-  loy = xhiJ[1];
-  while (curx < xhiJ[0]) {
-    amrex::Real cury = xloJ[1];
-    while (cury < xhiJ[1]) {
-      amrex::Real r2 = curx * curx + cury * cury;
-      if (r2 <= jr2) {
-        cur_jet_area += testdx2;
-        lox = amrex::min(curx, lox);
-        hix = amrex::max(curx, hix);
-        loy = amrex::min(cury, loy);
-        hiy = amrex::max(cury, hiy);
-      }
-      cury += testdx;
-    }
-    curx += testdx;
-  }
-#else
-  while (curx < xhiJ[0]) {
-    amrex::Real r2 = curx * curx;
-    if (r2 <= jr2) {
-      cur_jet_area += testdx;
-      lox = amrex::min(curx, lox);
-      hix = amrex::max(curx, hix);
-    }
-    curx += testdx;
-  }
-#endif
-  return cur_jet_area;
-}
+// file included is a standard jet injection calls
 
 amrex::RealVect
 jet_vel_comp(
@@ -75,11 +21,26 @@ jet_vel_comp(
   amrex::Real sp2 = std::sin(phi_2);
   amrex::Real cp2 = std::cos(phi_2);
   amrex::Real v1 = st1 * ct2 + st2 * cp2 * ct1;
-  amrex::RealVect vel;
-  AMREX_D_TERM(vel[0] = sp1 * v1 + sp2 * st2 * cp1;
-               , vel[1] = cp1 * v1 - sp2 * st2 * sp1;
-               , vel[2] = -st1 * st2 * cp2 + ct1 * ct2;);
+  amrex::RealVect vel(AMREX_D_DECL(
+    cp1 * v1 - sp1 * sp2 * st2, sp1 * v1 + sp2 * st2 * cp1,
+    ct1 * ct2 - st1 * st2 * cp2));
   return vel;
+}
+
+amrex::RealVect
+part_loc_trans(
+  amrex::Real radius, amrex::Real theta_1, amrex::Real phi_1, amrex::Real phi_2)
+{
+  amrex::Real st1 = std::sin(theta_1);
+  amrex::Real ct1 = std::cos(theta_1);
+  amrex::Real sp1 = std::sin(phi_1);
+  amrex::Real cp1 = std::cos(phi_1);
+  amrex::Real sp2 = std::sin(phi_2);
+  amrex::Real cp2 = std::cos(phi_2);
+  amrex::RealVect loc(AMREX_D_DECL(
+    radius * (cp1 * cp2 * ct1 - sp1 * sp2),
+    radius * (sp1 * cp2 * ct1 + cp1 * sp2), -radius * st1 * cp2));
+  return loc;
 }
 
 /*
@@ -89,7 +50,7 @@ jet_vel_comp(
  Cartesian. This is the jet_angle and azimuthal angles
  2: Spread spherical coordinates for spread of particle relative
  center of jet. This uses the spread_angle
- Within these coordinates, theta is the polar angle and phi is
+ Within these coordinates, theta is the inclination angle and phi is
  the azimuthal */
 
 template <class Dist>
@@ -97,6 +58,7 @@ void
 SprayParticleContainer::sprayInjection(
   Dist& dist_type,
   const amrex::RealVect jet_cent,
+  const amrex::RealVect jet_norm,
   const amrex::Real jet_dia,
   const amrex::Real part_temp,
   const amrex::Real mass_flow,
@@ -105,11 +67,18 @@ SprayParticleContainer::sprayInjection(
   const amrex::Real dt,
   const amrex::Real* Y_jet,
   const int level,
-  const amrex::Real jet_angle,
-  const amrex::Real azi_lo,
-  const amrex::Real azi_hi,
-  const int lowD)
+  int startInjProc,
+  int numInjProcs,
+  const bool hollow_spray)
 {
+#if AMREX_SPACEDIM == 2
+  // Do not parallelize injection for 2D
+  numInjProcs = 1;
+#endif
+  int curProc = amrex::ParallelDescriptor::MyProc();
+  if (curProc < startInjProc || curProc >= startInjProc + numInjProcs) {
+    return;
+  }
   const amrex::Geometry& geom = this->m_gdb->Geom(level);
   const auto plo = geom.ProbLoArray();
   const auto phi = geom.ProbHiArray();
@@ -119,14 +88,6 @@ SprayParticleContainer::sprayInjection(
   const int pstateDia = m_sprayIndx.pstateDia;
   const int pstateY = m_sprayIndx.pstateY;
   const SprayData* fdat = m_sprayData;
-  amrex::Real newdxmod = dx[0] / jet_dia * 10.;
-  amrex::Real dx_mod = amrex::max(50., newdxmod);
-  amrex::Real jr2 = jet_dia * jet_dia / 4.; // Jet radius squared
-#if AMREX_SPACEDIM == 3
-  amrex::Real jet_area = M_PI * jr2;
-#else
-  amrex::Real jet_area = jet_dia;
-#endif
   amrex::Real rho_part = 0.;
   for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
     rho_part += Y_jet[spf] / fdat->rhoL(part_temp, spf);
@@ -138,112 +99,90 @@ SprayParticleContainer::sprayInjection(
 
   amrex::RealVect dom_len(
     AMREX_D_DECL(geom.ProbLength(0), geom.ProbLength(1), geom.ProbLength(2)));
-  amrex::Real theta_1 = jet_angle;
-  amrex::Real theta_2_lo = -0.5 * spread_angle;
-  // Range for the azimuthal coordinate
-  amrex::Real phi_range = azi_hi - azi_lo;
-
-  for (amrex::MFIter mfi = MakeMFIter(level); mfi.isValid(); ++mfi) {
-    const amrex::Box& bx = mfi.tilebox();
-    const amrex::RealBox& temp =
-      amrex::RealBox(bx, geom.CellSize(), geom.ProbLo());
-    const amrex::Real* xloB = temp.lo();
-    const amrex::Real* xhiB = temp.hi();
-    const amrex::Real jet_norm = jet_cent[lowD];
-    if (xloB[lowD] <= jet_norm && xhiB[lowD] > jet_norm) {
-      amrex::Gpu::HostVector<ParticleType> host_particles;
-      amrex::RealVect xlo;
-      amrex::RealVect xhi;
-      for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-        xlo[dir] = amrex::max(xloB[dir], jet_cent[dir] - 3. * jet_dia);
-        xhi[dir] = amrex::min(xhiB[dir], jet_cent[dir] + 3. * jet_dia);
-      }
-      amrex::RealVect xloJ;
-      amrex::RealVect xhiJ;
-      for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-        xloJ[dir] = xlo[dir] - jet_cent[dir];
-        xhiJ[dir] = xhi[dir] - jet_cent[dir];
-      }
-      // Set jet to lower Y domain for 2D and lower Z domain for 3D
-      xloJ[lowD] = jet_cent[lowD];
-      xhiJ[lowD] = jet_cent[lowD];
-      amrex::Real lox, hix;
+  amrex::ParticleLocData pld;
+  std::map<std::pair<int, int>, amrex::Gpu::HostVector<ParticleType>>
+    host_particles;
+  amrex::Real cur_mass = 0.;
+  amrex::Real inject_mass = mass_flow * dt;
+  amrex::Real norm = jet_norm.vectorLength();
+  amrex::Real injProcs = static_cast<amrex::Real>(numInjProcs);
 #if AMREX_SPACEDIM == 3
-      amrex::Real loy, hiy;
-      amrex::Real cur_jet_area = jetOverlapArea(
-        dx[0] / dx_mod, xloJ, xhiJ, jet_cent, jr2, loy, hiy, lox, hix);
-      amrex::Real ylen = hiy - loy;
-      loy += jet_cent[1];
+  amrex::Real theta_1 = std::acos(jet_norm[2] / norm);
+  amrex::Real phi_1 = std::atan2(jet_norm[1] / norm, jet_norm[0] / norm);
+  amrex::Real dphi = 2. * M_PI / injProcs;
+  amrex::Real phi_2_lo = amrex::ParallelDescriptor::MyProc() * dphi;
 #else
-      amrex::Real cur_jet_area =
-        jetOverlapArea(dx[0] / dx_mod, xloJ, xhiJ, jet_cent, jr2, lox, hix);
+  amrex::Real theta_1 = std::atan2(jet_norm[1], jet_norm[0]) + M_PI / 2.;
 #endif
-      amrex::Real xlen = hix - lox;
-      lox += jet_cent[0];
-      if (cur_jet_area > 0.) {
-        amrex::Real jet_perc = cur_jet_area / jet_area;
-        amrex::Real perc_mass = jet_perc * mass_flow * dt;
-        amrex::Real total_mass = 0.;
-        while (total_mass < perc_mass) {
-          amrex::RealVect part_loc;
-          part_loc[0] = lox + amrex::Random() * xlen;
-          AMREX_D_PICK(, part_loc[1] = jet_norm;
-                       , part_loc[1] = loy + amrex::Random() * ylen;
-                       part_loc[2] = jet_norm;)
-          amrex::Real r2 = AMREX_D_TERM(
-            std::pow(part_loc[0] - jet_cent[0], 2), ,
-            +std::pow(part_loc[1] - jet_cent[1], 2));
-          if (r2 <= jr2) {
-            ParticleType p;
-            p.id() = ParticleType::NextID();
-            p.cpu() = amrex::ParallelDescriptor::MyProc();
-            // Determine the polar angle for the spread where 0 is perpendicular
-            // to the theta_2 axis
-            amrex::Real theta_2 = theta_2_lo + amrex::Random() * spread_angle;
-#if AMREX_SPACEDIM == 3
-            // Determine the azimuthal angle for the jet center
-            amrex::Real phi_1 = azi_lo + amrex::Random() * phi_range;
-            // Determine the azimuthal angle for the spread
-            amrex::Real phi_2 = 2. * M_PI * amrex::Random();
-            amrex::RealVect part_vel =
-              jet_vel_comp(theta_1, phi_1, theta_2, phi_2);
-#else
-            amrex::Real thetas = theta_1 + theta_2;
-            amrex::RealVect part_vel(std::sin(thetas), std::cos(thetas));
-#endif
-            AMREX_D_TERM(p.rdata(pstateVel) = jet_vel * part_vel[0];
-                         , p.rdata(pstateVel + 1) = jet_vel * part_vel[1];
-                         , p.rdata(pstateVel + 2) = jet_vel * part_vel[2];);
-            amrex::Real cur_dia = dist_type.get_dia();
-            // Add particles as if they have advanced some random portion of
-            // dt
-            amrex::Real pmov = amrex::Random();
-            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-              p.pos(dir) = part_loc[dir] + pmov * dt * p.rdata(pstateVel + dir);
-            }
-            p.rdata(pstateT) = part_temp;
-            p.rdata(pstateDia) = cur_dia;
-            for (int sp = 0; sp < SPRAY_FUEL_NUM; ++sp) {
-              p.rdata(pstateY + sp) = Y_jet[sp];
-            }
-            host_particles.push_back(p);
-            amrex::Real pmass = Pi_six * rho_part * std::pow(cur_dia, 3);
-            total_mass += num_ppp * pmass;
-          }
-        }
-      }
-      if (host_particles.size() > 0) {
-        auto& particle_tile = GetParticles(
-          level)[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
-        auto old_size = particle_tile.GetArrayOfStructs().size();
-        auto new_size = old_size + host_particles.size();
-        particle_tile.resize(new_size);
-        amrex::Gpu::copy(
-          amrex::Gpu::hostToDevice, host_particles.begin(),
-          host_particles.end(),
-          particle_tile.GetArrayOfStructs().begin() + old_size);
-      }
+  amrex::real mass_perc = inject_mass / injProcs;
+  while (cur_mass < mass_perc) {
+    // Pick random percentage from 0 to 1
+    amrex::Real radp = amrex::Random();
+    if (hollow_spray) {
+      radp = 1.;
     }
+#if AMREX_SPACEDIM == 3
+    // This determines the radial location of the particle within the jet inlet
+    amrex::Real cur_rad = radp * jet_dia / 2.;
+    // The closer the particle is to the edge of the injection circle, the
+    // greater the spread angle
+    amrex::Real theta_2 = radp * spread_angle / 2.;
+    // Pick random azimuthal angle relative to jet inlet CS
+    // Each processor is only injecting a portion of the circle
+    amrex::Real phi_2 = phi_2_lo + amrex::Random() * dphi;
+    amrex::RealVect part_loc =
+      jet_cent + part_loc_trans(cur_rad, theta_1, phi_1, phi_2);
+    amrex::RealVect part_vel = jet_vel_comp(theta_1, phi_1, theta_2, phi_2);
+#else
+    amrex::Real cur_rad = (radp - 0.5) * 0.5 * jet_dia;
+    amrex::Real theta_2 = -(radp - 0.5) * spread_angle;
+    amrex::Real st1 = std::sin(theta_1);
+    amrex::Real ct1 = std::cos(theta_1);
+    amrex::Real st2 = std::sin(theta_2);
+    amrex::Real ct2 = std::cos(theta_2);
+    amrex::RealVect part_loc(
+      jet_cent[0] + cur_rad * ct1, jet_cent[1] + cur_rad * st1);
+    amrex::RealVect part_vel(st1 * ct2 - st2 * ct1, -ct1 * ct2 - st1 * st2);
+#endif
+    ParticleType p;
+    p.id() = ParticleType::NextID();
+    p.cpu() = amrex::ParallelDescriptor::MyProc();
+    AMREX_D_TERM(p.rdata(pstateVel) = jet_vel * part_vel[0];
+                 , p.rdata(pstateVel + 1) = jet_vel * part_vel[1];
+                 , p.rdata(pstateVel + 2) = jet_vel * part_vel[2];);
+    amrex::Real cur_dia = dist_type.get_dia();
+    // Add particles as if they have advanced some random portion of
+    // dt
+    amrex::Real pmov = amrex::Random();
+    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+      p.pos(dir) = part_loc[dir] + pmov * dt * p.rdata(pstateVel + dir);
+    }
+    p.rdata(pstateT) = part_temp;
+    p.rdata(pstateDia) = cur_dia;
+    for (int sp = 0; sp < SPRAY_FUEL_NUM; ++sp) {
+      p.rdata(pstateY + sp) = Y_jet[sp];
+    }
+    bool where = Where(p, pld);
+    if (!where) {
+      amrex::Abort("Bad injection particle");
+    }
+    std::pair<int, int> ind(pld.m_grid, pld.m_tile);
+    host_particles[ind].push_back(p);
+    amrex::Real pmass = Pi_six * rho_part * std::pow(cur_dia, 3);
+    cur_mass += num_ppp * pmass;
+  }
+  for (auto& kv : host_particles) {
+    auto grid = kv.first.first;
+    auto tile = kv.first.second;
+    const auto& src_tile = kv.second;
+    auto& dst_tile = GetParticles(level)[std::make_pair(grid, tile)];
+    auto old_size = dst_tile.GetArrayOfStructs().size();
+    auto new_size = old_size + src_tile.size();
+    dst_tile.resize(new_size);
+    // Copy the AoS part of the host particles to the GPU
+    amrex::Gpu::copy(
+      amrex::Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
+      dst_tile.GetArrayOfStructs().begin() + old_size);
   }
 }
 #endif

--- a/Source/PP_Spray/SprayParticles.H
+++ b/Source/PP_Spray/SprayParticles.H
@@ -77,6 +77,7 @@ public:
   void sprayInjection(
     Dist& dist_type,
     const amrex::RealVect jet_cent,
+    const amrex::RealVect jet_norm,
     const amrex::Real jet_dia,
     const amrex::Real part_temp,
     const amrex::Real mass_flow,
@@ -85,10 +86,9 @@ public:
     const amrex::Real dt,
     const amrex::Real* Y_jet,
     const int level,
-    const amrex::Real jet_angle = 0.,
-    const amrex::Real azi_lo = 0.,
-    const amrex::Real azi_hi = 360.,
-    const int lowD = AMREX_SPACEDIM - 1);
+    int startInjProc = 0,
+    int numInjProcs = 1,
+    const bool hollow_spray = false);
 
   static void readSprayParams(
     int& particle_verbose,


### PR DESCRIPTION
Redid the spray injection routine. Now particle injection velocities vary according to their location within the injector. For example, a particle near the outer edge of the injection site will have a larger tangential velocity component than a particle injected in the center, which will only have a normal velocity component. This PR also allows for jets to have any normal direction. Before they had to be normal to a Cartesian direction.