### PR TITLE
Simplify spray data

### DIFF
--- a/Exec/SprayTests/PeleC/HPC_spray_test/node-input
+++ b/Exec/SprayTests/PeleC/HPC_spray_test/node-input
@@ -59,7 +59,6 @@ particles.v = 2
 particles.mom_transfer = 1
 particles.mass_transfer = 1
 particles.cfl = 0.5
-particles.init_function = 1 # Use SprayParticlesInitInsert.cpp for initialization
 particles.write_ascii_files = 0 # Do not write ascii output files
 
 particles.fuel_species = NC10H22

--- a/Exec/SprayTests/PeleC/Multijet/first-input
+++ b/Exec/SprayTests/PeleC/Multijet/first-input
@@ -12,7 +12,7 @@ amr.n_cell = 32 32 32
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 pelec.lo_bc        = "Interior" "NoSlipWall" "Interior"
-pelec.hi_bc        = "Interior" "Hard" "Interior"
+pelec.hi_bc        = "Interior" "FOExtrap" "Interior"
 
 # WHICH PHYSICS
 pelec.do_hydro = 1
@@ -64,8 +64,6 @@ pelec.do_spray_particles = 1
 particles.v = 0
 particles.mom_transfer = 1
 particles.mass_transfer = 1
-# Set so that SprayParticleInitInsert.cpp is used to initialize
-particles.init_function = 1
 particles.write_ascii_files = 0
 
 # Number of particles per parcel

--- a/Exec/SprayTests/PeleC/TG_GPU/inputs_2d
+++ b/Exec/SprayTests/PeleC/TG_GPU/inputs_2d
@@ -54,7 +54,6 @@ particles.v = 0
 particles.mom_transfer = 0
 particles.mass_transfer = 0
 particles.cfl = 0.5
-particles.init_function = 1 # Use SprayParticlesInitInsert.cpp for initialization
 particles.write_ascii_files = 0 # Do not write ascii output files
 
 particles.fuel_ref_temp = 298.15

--- a/Exec/SprayTests/PeleC/abramzon_test/inputs_2d
+++ b/Exec/SprayTests/PeleC/abramzon_test/inputs_2d
@@ -12,8 +12,8 @@ amr.n_cell           = 256 16
 
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
-pelec.lo_bc        = "Hard" "Interior"
-pelec.hi_bc        = "Hard" "Interior"
+pelec.lo_bc        = "FOExtrap" "Interior"
+pelec.hi_bc        = "FOExtrap" "Interior"
 
 # WHICH PHYSICS
 pelec.do_hydro = 1
@@ -54,7 +54,6 @@ particles.derive_plot_vars = 0
 particles.v = 0
 particles.mom_transfer = 1
 particles.mass_transfer = 1
-particles.init_function = 0
 particles.init_file = "initspraydata"
 particles.write_ascii_files = 1
 

--- a/Exec/SprayTests/PeleC/abramzon_test/inputs_2d_mol
+++ b/Exec/SprayTests/PeleC/abramzon_test/inputs_2d_mol
@@ -12,8 +12,8 @@ amr.n_cell           = 256 16
 
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
-pelec.lo_bc        = "Hard" "Interior"
-pelec.hi_bc        = "Hard" "Interior"
+pelec.lo_bc        = "FOExtrap" "Interior"
+pelec.hi_bc        = "FOExtrap" "Interior"
 
 # WHICH PHYSICS
 pelec.do_hydro = 1
@@ -54,7 +54,6 @@ pelec.do_spray_particles = 1
 particles.v = 0
 particles.mom_transfer = 1
 particles.mass_transfer = 1
-particles.init_function = 0
 particles.init_file = "initspraydata"
 particles.write_ascii_files = 1
 

--- a/Exec/SprayTests/PeleC/gammaTG/inputs_2d
+++ b/Exec/SprayTests/PeleC/gammaTG/inputs_2d
@@ -48,7 +48,7 @@ pelec.sum_interval   = -1  # timesteps between computing mass
 pelec.v              = 0   # verbosity in Castro.cpp
 amr.v                = 1   # verbosity in Amr.cpp
 
-# REFINEMENT / REGRIDDING 
+# REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed
 amr.ref_ratio       = 2 2 2 2 # refinement ratio
 amr.regrid_int      = 2 2 2 2 # how often to regrid
@@ -60,7 +60,6 @@ pelec.do_spray_particles = 1
 particles.v = 0
 particles.mom_transfer = 0 # Gas phase has no spray momentum source term
 particles.mass_transfer = 0 # No evaporation takes place
-particles.init_function = 1 # Use SprayParticlesInitInsert.cpp for initialization
 particles.write_ascii_files = 0 # Do not write ascii output files
 
 particles.fuel_ref_temp = 300.

--- a/Exec/SprayTests/PeleC/heptane_evap/input2d
+++ b/Exec/SprayTests/PeleC/heptane_evap/input2d
@@ -34,7 +34,7 @@ pelec.cfl            = 0.8     # cfl number for hyperbolic system
 pelec.init_shrink    = 0.3     # scale back initial timestep
 pelec.change_max     = 1.1     # max time step growth
 pelec.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
-#pelec.fixed_dt       = 1.e-5  
+#pelec.fixed_dt       = 1.e-5
 
 
 # DIAGNOSTICS & VERBOSITY
@@ -44,7 +44,7 @@ amr.v                = 1       # verbosity in Amr.cpp
 #amr.data_log         = datlog
 #amr.grid_log        = grdlog  # name of grid logging file
 
-# REFINEMENT / REGRIDDING 
+# REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed
 amr.ref_ratio       = 2 2 2 2 # refinement ratio
 amr.regrid_int      = 2 2 2 2 # how often to regrid
@@ -58,7 +58,6 @@ particles.derive_plot_vars = 1
 particles.fixed_parts = 1
 particles.mom_transfer = 1
 particles.mass_transfer = 1
-particles.init_function = 0
 particles.init_file = "initsprayfile"
 particles.write_ascii_files = 1
 

--- a/Exec/SprayTests/PeleC/jet_spray/inputs-2d
+++ b/Exec/SprayTests/PeleC/jet_spray/inputs-2d
@@ -11,8 +11,8 @@ amr.n_cell           = 32 224 32
 
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
-pelec.lo_bc        = "Hard" "NoSlipWall" "Hard"
-pelec.hi_bc        = "Hard" "Hard" "Hard"
+pelec.lo_bc        = "FOExtrap" "NoSlipWall" "FOExtrap"
+pelec.hi_bc        = "FOExtrap" "FOExtrap" "FOExtrap"
 
 # WHICH PHYSICS
 pelec.do_hydro = 1
@@ -63,8 +63,6 @@ particles.v = 0
 particles.derive_plot_vars = 1
 particles.mom_transfer = 1
 particles.mass_transfer = 1
-# Set so that SprayParticleInitInsert.cpp is used to initialize
-particles.init_function = 1
 particles.write_ascii_files = 0
 
 # Number of particles per parcel

--- a/Exec/SprayTests/PeleLMeX/TG/input.2d
+++ b/Exec/SprayTests/PeleLMeX/TG/input.2d
@@ -10,7 +10,7 @@ geometry.prob_hi     = 1. 1. 1.        # x_hi y_hi (z_hi)
 peleLM.lo_bc = Interior Interior
 peleLM.hi_bc = Interior Interior
 
-particles.cfl = 4.
+particles.cfl = 2.
 
 #amr.restart = chk00005
 #amr.check_int = 10
@@ -34,7 +34,6 @@ prob.reynolds = 1600.
 prob.mach = 0.1
 prob.density_ratio = 10000.
 prob.st_mod = 20.
-# Particle parameters, only used if particles.init_function = 1
 prob.num_particles = (128, 128, 128)
 
 #-------------------------PeleLM CONTROL----------------------------
@@ -81,8 +80,6 @@ particles.N2_rho = 11379.8
 particles.N2_psat = 4.07857 1501.268 -78.67 1.E5
 
 particles.use_splash_model = false
-
-particles.init_function = 1
 
 particles.v             = 0
 particles.mom_transfer  = 0

--- a/Exec/SprayTests/PeleLMeX/abramzon_test/inputs_2d
+++ b/Exec/SprayTests/PeleLMeX/abramzon_test/inputs_2d
@@ -77,7 +77,6 @@ particles.NC10H22_rho = 640.
 particles.NC10H22_psat = 4.07857 1501.268 -78.67 1.E5
 
 particles.use_splash_model = false
-particles.init_function = 1
 
 particles.v             = 0
 particles.fixed_parts   = 0 # To fix the particle in space

--- a/Exec/SprayTests/PeleLMeX/dist_test/first-input
+++ b/Exec/SprayTests/PeleLMeX/dist_test/first-input
@@ -10,7 +10,7 @@ geometry.prob_hi     = 10. 10. 10.        # x_hi y_hi (z_hi)
 peleLM.lo_bc = Interior SlipWallAdiab
 peleLM.hi_bc = Interior SlipWallAdiab
 
-particles.cfl = 4.
+particles.cfl = 2.
 
 #amr.restart = chk00005
 #amr.check_int = 10
@@ -42,7 +42,6 @@ prob.P_mean = 101325.0
 prob.init_T = 500.
 prob.init_vel = 0.0
 
-# Particle parameters, only used if particles.init_function = 1
 prob.num_particles = (256, 256, 256)
 prob.init_redist   = 1
 prob.part_temp     = 300.
@@ -110,10 +109,6 @@ particles.NC10H22_rho = 640.
 particles.NC10H22_psat = 4.07857 1501.268 -78.67 1.E5
 
 particles.use_splash_model = false
-
-# particles.init_function = 0
-# particles.init_file = "initspraydata"
-particles.init_function = 1
 
 particles.v             = 2
 particles.mom_transfer  = 1

--- a/Exec/SprayTests/PeleLMeX/spray_flame/input.2d
+++ b/Exec/SprayTests/PeleLMeX/spray_flame/input.2d
@@ -117,8 +117,6 @@ particles.NC10H22_psat = 4.07857 1501.268 -78.67 1.E5
 
 particles.use_splash_model = false
 
-particles.init_function = 1
-
 particles.v             = 0
 particles.mom_transfer  = 1
 particles.mass_transfer = 1

--- a/Exec/SprayTests/PeleLMeX/spray_flame/input.3d
+++ b/Exec/SprayTests/PeleLMeX/spray_flame/input.3d
@@ -118,8 +118,6 @@ particles.NC10H22_psat = 4.07857 1501.268 -78.67 1.E5
 
 particles.use_splash_model = false
 
-particles.init_function = 1
-
 particles.v             = 0
 particles.mom_transfer  = 1
 particles.mass_transfer = 1

--- a/Exec/SprayTests/PeleLMeX/user_jet/input.3d
+++ b/Exec/SprayTests/PeleLMeX/user_jet/input.3d
@@ -100,8 +100,6 @@ particles.NC10H22_psat = 4.07857 1501.268 -78.67 1.E5
 
 particles.use_splash_model = false
 
-particles.init_function = 1
-
 particles.v             = 0
 particles.mom_transfer  = 1
 particles.mass_transfer = 1

--- a/Source/PP_Spray/Drag.H
+++ b/Source/PP_Spray/Drag.H
@@ -327,8 +327,6 @@ calculateSpraySource(
         for (int spf = 0; spf < SPRAY_FUEL_NUM; ++spf) {
           // Species index
           const int fspec = fdat.indx[spf];
-          // Gas species index, might be the same
-          const int fdspec = fdat.dep_indx[spf];
           if (X_vapor[spf] > 0.) {
             mi_dot[spf] = -amrex::max(Ddiag[fspec] * mdotcoeff, 0.);
             m_dot += mi_dot[spf];

--- a/Source/PP_Spray/SprayIO.cpp
+++ b/Source/PP_Spray/SprayIO.cpp
@@ -5,9 +5,7 @@ using namespace amrex;
 
 void
 SprayParticleContainer::SprayParticleIO(
-  const int level,
-  const bool is_checkpoint,
-  const std::string& dir)
+  const int level, const bool is_checkpoint, const std::string& dir)
 {
   Vector<std::string> real_comp_names(NSR_SPR);
   AMREX_D_TERM(real_comp_names[SprayComps::pstateVel] = "xvel";

--- a/Source/PP_Spray/SprayIO.cpp
+++ b/Source/PP_Spray/SprayIO.cpp
@@ -7,7 +7,6 @@ void
 SprayParticleContainer::SprayParticleIO(
   const int level,
   const bool is_checkpoint,
-  const int write_ascii,
   const std::string& dir)
 {
   Vector<std::string> real_comp_names(NSR_SPR);
@@ -23,7 +22,7 @@ SprayParticleContainer::SprayParticleIO(
   Vector<std::string> int_comp_names;
   Checkpoint(dir, "particles", is_checkpoint, real_comp_names, int_comp_names);
   // Here we write ascii information every time we write a plot file
-  if (level == 0 && write_ascii == 1) {
+  if (level == 0 && SprayParticleContainer::write_ascii_files) {
     size_t num_end_loc = dir.find_last_of("0123456789") + 1;
     // Remove anything following numbers, like .temp
     std::string dirout = dir.substr(0, num_end_loc);

--- a/Source/PP_Spray/SprayInterpolation.H
+++ b/Source/PP_Spray/SprayInterpolation.H
@@ -547,7 +547,7 @@ eb_interp(
       }
     }
     // Normalize weighting
-    for (int aindx = 0; aindx < AMREX_D_PICK(2, 4, 8); ++aindx) {
+    for (aindx = 0; aindx < AMREX_D_PICK(2, 4, 8); ++aindx) {
       weights[aindx] /= sum_wt;
     }
     ijkc = indx_array[closest_aindx];

--- a/Source/PP_Spray/SprayParticles.H
+++ b/Source/PP_Spray/SprayParticles.H
@@ -83,7 +83,8 @@ public:
 
   /// \brief Spray particle write routine, writes plot, checkpoint, ascii, and
   /// injection data files
-  void SprayParticleIO(const int level, const bool is_checkpoint, const std::string& dir);
+  void SprayParticleIO(
+    const int level, const bool is_checkpoint, const std::string& dir);
 
   /// \brief Derive grid variables related to sprays
   void computeDerivedVars(
@@ -317,7 +318,8 @@ public:
 #endif
   );
 
-  /// \brief Generalized initializer routine. Calls #InitSprayParticles and #PostInitRestart
+  /// \brief Generalized initializer routine. Calls #InitSprayParticles and
+  /// #PostInitRestart
   void SprayInitialize(
 #ifdef PELELM_USE_SPRAY
     ProbParm const& prob_parm,
@@ -325,8 +327,7 @@ public:
     ProbParmHost const& prob_parm,
     ProbParmDevice const& prob_parm_d,
 #endif
-    const std::string& restart_dir = ""
-  );
+    const std::string& restart_dir = "");
 
   /// \brief Problem specific initialization routine. Typically initializes the
   /// SprayJet pointers or calls #uniformSprayInit
@@ -359,27 +360,15 @@ public:
   }
 
   /// \brief Return host spray data pointer
-  static SprayData* getSprayData()
-  {
-    return m_sprayData;
-  }
+  static SprayData* getSprayData() { return m_sprayData; }
 
   /// \brief Return fuel species index
-  static int getFuelIndx(const int spf)
-  {
-    return m_sprayData->dep_indx[spf];
-  }
+  static int getFuelIndx(const int spf) { return m_sprayData->dep_indx[spf]; }
 
   /// \brief Return spray indices
-  static SprayComps getSprayComps()
-  {
-    return m_sprayIndx;
-  }
+  static SprayComps getSprayComps() { return m_sprayIndx; }
 
-  static void AssignSprayComps(SprayComps scomps)
-  {
-    m_sprayIndx = scomps;
-  }
+  static void AssignSprayComps(SprayComps scomps) { m_sprayIndx = scomps; }
 
   static std::string m_sprayFuelNames[SPRAY_FUEL_NUM];
   static std::string m_sprayDepNames[SPRAY_FUEL_NUM];

--- a/Source/PP_Spray/SprayParticles.H
+++ b/Source/PP_Spray/SprayParticles.H
@@ -38,27 +38,14 @@ public:
   using HostVectReal = amrex::Gpu::HostVector<amrex::Real>;
   using HostVectInt = amrex::Gpu::HostVector<int>;
 
-  SprayParticleContainer(
-    amrex::AmrCore* amr,
-    amrex::BCRec* _phys_bc,
-    const SprayData& fdat,
-    const SprayComps& SPI,
-    amrex::Real part_cfl = -1.)
+  SprayParticleContainer(amrex::AmrCore* amr, amrex::BCRec* _phys_bc)
     : amrex::AmrParticleContainer<NSR_SPR, NSI_SPR, NAR_SPR, NAI_SPR>(amr),
-      phys_bc(_phys_bc),
-      m_sprayData(new SprayData{}),
-      m_sprayIndx(SPI),
-      m_partCFL(part_cfl)
+      phys_bc(_phys_bc)
   {
-    d_sprayData =
-      static_cast<SprayData*>(amrex::The_Arena()->alloc(sizeof(SprayData)));
-    std::memcpy(m_sprayData, &(fdat), sizeof(SprayData));
-    amrex::Gpu::copy(
-      amrex::Gpu::hostToDevice, m_sprayData, m_sprayData + 1, d_sprayData);
     init_bcs();
   }
 
-  ~SprayParticleContainer() override
+  static void SprayCleanUp()
   {
     delete m_sprayData;
     amrex::The_Arena()->free(d_sprayData);
@@ -89,26 +76,14 @@ public:
     const int num_redist = 1);
 
   /// \brief Setup spray parameters
-  static void spraySetup(SprayData& sprayData, const amrex::Real* body_force);
+  static void spraySetup(const amrex::Real* body_force);
 
   /// \brief Read in spray parameters from input file
-  static void readSprayParams(
-    int& particle_verbose,
-    amrex::Real& particle_cfl,
-    int& write_spray_ascii_files,
-    int& plot_spray_src,
-    int& init_function,
-    std::string& init_file,
-    SprayData& sprayData,
-    const amrex::Real& max_cfl = 0.5);
+  static void readSprayParams(int& particle_verbose);
 
   /// \brief Spray particle write routine, writes plot, checkpoint, ascii, and
   /// injection data files
-  void SprayParticleIO(
-    const int level,
-    const bool is_checkpoint,
-    const int write_ascii,
-    const std::string& dir);
+  void SprayParticleIO(const int level, const bool is_checkpoint, const std::string& dir);
 
   /// \brief Derive grid variables related to sprays
   void computeDerivedVars(
@@ -116,7 +91,7 @@ public:
 
   /// \brief Compute a maximum time step based on the particle velocities and a
   /// particle CFL number
-  amrex::Real estTimestep(int level, amrex::Real cfl) const;
+  amrex::Real estTimestep(int level) const;
 
   /// \brief Reset the particle ID in case we need to reinitialize the particles
   static inline void resetID(const int id) { ParticleType::NextID(id); }
@@ -342,6 +317,17 @@ public:
 #endif
   );
 
+  /// \brief Generalized initializer routine. Calls #InitSprayParticles and #PostInitRestart
+  void SprayInitialize(
+#ifdef PELELM_USE_SPRAY
+    ProbParm const& prob_parm,
+#else
+    ProbParmHost const& prob_parm,
+    ProbParmDevice const& prob_parm_d,
+#endif
+    const std::string& restart_dir = ""
+  );
+
   /// \brief Problem specific initialization routine. Typically initializes the
   /// SprayJet pointers or calls #uniformSprayInit
   void InitSprayParticles(
@@ -372,9 +358,39 @@ public:
     return m_sprayDeriveVars;
   }
 
+  /// \brief Return host spray data pointer
+  static SprayData* getSprayData()
+  {
+    return m_sprayData;
+  }
+
+  /// \brief Return fuel species index
+  static int getFuelIndx(const int spf)
+  {
+    return m_sprayData->dep_indx[spf];
+  }
+
+  /// \brief Return spray indices
+  static SprayComps getSprayComps()
+  {
+    return m_sprayIndx;
+  }
+
+  static void AssignSprayComps(SprayComps scomps)
+  {
+    m_sprayIndx = scomps;
+  }
+
   static std::string m_sprayFuelNames[SPRAY_FUEL_NUM];
   static std::string m_sprayDepNames[SPRAY_FUEL_NUM];
   static amrex::Vector<std::string> m_sprayDeriveVars;
+  static SprayData* m_sprayData;
+  static SprayData* d_sprayData;
+  static SprayComps m_sprayIndx;
+  static amrex::Real spray_cfl;
+  static bool write_ascii_files;
+  static bool plot_spray_src;
+  static std::string spray_init_file;
 
 private:
   /// \brief This defines reflect_lo and reflect_hi from phys_bc
@@ -383,11 +399,6 @@ private:
   amrex::BCRec* phys_bc;
   bool reflect_lo[AMREX_SPACEDIM];
   bool reflect_hi[AMREX_SPACEDIM];
-  SprayData* m_sprayData;
-  SprayData* d_sprayData = nullptr;
-  SprayComps m_sprayIndx;
-  // Particle CFL, used for injection cases with LMeX
-  amrex::Real m_partCFL;
   amrex::Vector<std::unique_ptr<SprayJet>> m_sprayJets;
 };
 

--- a/Source/PP_Spray/SprayParticles.cpp
+++ b/Source/PP_Spray/SprayParticles.cpp
@@ -84,14 +84,14 @@ SprayParticleContainer::moveKickDrift(
 }
 
 Real
-SprayParticleContainer::estTimestep(int level, Real cfl) const
+SprayParticleContainer::estTimestep(int level) const
 {
   BL_PROFILE("ParticleContainer::estTimestep()");
   Real dt = std::numeric_limits<Real>::max();
   if (level >= this->GetParticles().size() || m_sprayData->fixed_parts) {
     return -1.;
   }
-
+  const Real cfl = SprayParticleContainer::spray_cfl;
   const auto dx = Geom(level).CellSizeArray();
   const auto dxi = Geom(level).InvCellSizeArray();
   {

--- a/Source/PP_Spray/SpraySetup.cpp
+++ b/Source/PP_Spray/SpraySetup.cpp
@@ -79,9 +79,9 @@ SprayParticleContainer::readSprayParams(int& particle_verbose)
   pp.query("mom_transfer", m_sprayData->mom_trans);
   pp.query("fixed_parts", m_sprayData->fixed_parts);
 #ifdef PELELM_USE_SPRAY
-  int max_cfl = 2.;
+  Real max_cfl = 2.;
 #else
-  int max_cfl = 0.5;
+  Real max_cfl = 0.5;
 #endif
   pp.query("cfl", spray_cfl);
   if (spray_cfl > max_cfl) {

--- a/Source/PP_Spray/SpraySetup.cpp
+++ b/Source/PP_Spray/SpraySetup.cpp
@@ -6,6 +6,13 @@ using namespace amrex;
 std::string SprayParticleContainer::m_sprayFuelNames[SPRAY_FUEL_NUM];
 std::string SprayParticleContainer::m_sprayDepNames[SPRAY_FUEL_NUM];
 Vector<std::string> SprayParticleContainer::m_sprayDeriveVars;
+SprayData* SprayParticleContainer::m_sprayData = nullptr;
+SprayData* SprayParticleContainer::d_sprayData = nullptr;
+SprayComps SprayParticleContainer::m_sprayIndx;
+Real SprayParticleContainer::spray_cfl = 0.5;
+bool SprayParticleContainer::write_ascii_files = false;
+bool SprayParticleContainer::plot_spray_src = false;
+std::string SprayParticleContainer::spray_init_file = "";
 
 void
 getInpCoef(
@@ -59,26 +66,25 @@ getInpVal(
 }
 
 void
-SprayParticleContainer::readSprayParams(
-  int& particle_verbose,
-  Real& particle_cfl,
-  int& write_spray_ascii_files,
-  int& plot_spray_src,
-  int& init_function,
-  std::string& init_file,
-  SprayData& sprayData,
-  const Real& max_cfl)
+SprayParticleContainer::readSprayParams(int& particle_verbose)
 {
+  m_sprayData = new SprayData{};
+  d_sprayData =
+    static_cast<SprayData*>(amrex::The_Arena()->alloc(sizeof(SprayData)));
   ParmParse pp("particles");
-  //
   // Control the verbosity of the Particle class
   pp.query("v", particle_verbose);
 
-  pp.query("mass_transfer", sprayData.mass_trans);
-  pp.query("mom_transfer", sprayData.mom_trans);
-  pp.query("fixed_parts", sprayData.fixed_parts);
-  pp.query("cfl", particle_cfl);
-  if (particle_cfl > max_cfl) {
+  pp.query("mass_transfer", m_sprayData->mass_trans);
+  pp.query("mom_transfer", m_sprayData->mom_trans);
+  pp.query("fixed_parts", m_sprayData->fixed_parts);
+#ifdef PELELM_USE_SPRAY
+  int max_cfl = 2.;
+#else
+  int max_cfl = 0.5;
+#endif
+  pp.query("cfl", spray_cfl);
+  if (spray_cfl > max_cfl) {
     Abort("particles.cfl must be <= " + std::to_string(max_cfl));
   }
   // Number of fuel species in spray droplets
@@ -97,15 +103,15 @@ SprayParticleContainer::readSprayParams(
       has_dep_spec = true;
       pp.getarr("dep_fuel_species", dep_fuel_names);
     }
-    getInpVal(sprayData.critT.data(), pp, fuel_names.data(), "crit_temp");
-    getInpVal(sprayData.boilT.data(), pp, fuel_names.data(), "boil_temp");
-    getInpVal(sprayData.cp.data(), pp, fuel_names.data(), "cp");
-    getInpVal(sprayData.ref_latent.data(), pp, fuel_names.data(), "latent");
+    getInpVal(m_sprayData->critT.data(), pp, fuel_names.data(), "crit_temp");
+    getInpVal(m_sprayData->boilT.data(), pp, fuel_names.data(), "boil_temp");
+    getInpVal(m_sprayData->cp.data(), pp, fuel_names.data(), "cp");
+    getInpVal(m_sprayData->ref_latent.data(), pp, fuel_names.data(), "latent");
 
-    getInpCoef(sprayData.lambda_coef.data(), pp, fuel_names.data(), "lambda");
-    getInpCoef(sprayData.psat_coef.data(), pp, fuel_names.data(), "psat");
-    getInpCoef(sprayData.rho_coef.data(), pp, fuel_names.data(), "rho", true);
-    getInpCoef(sprayData.mu_coef.data(), pp, fuel_names.data(), "mu");
+    getInpCoef(m_sprayData->lambda_coef.data(), pp, fuel_names.data(), "lambda");
+    getInpCoef(m_sprayData->psat_coef.data(), pp, fuel_names.data(), "psat");
+    getInpCoef(m_sprayData->rho_coef.data(), pp, fuel_names.data(), "rho", true);
+    getInpCoef(m_sprayData->mu_coef.data(), pp, fuel_names.data(), "mu");
     for (int i = 0; i < nfuel; ++i) {
       m_sprayFuelNames[i] = fuel_names[i];
       if (has_dep_spec) {
@@ -113,7 +119,7 @@ SprayParticleContainer::readSprayParams(
       } else {
         m_sprayDepNames[i] = m_sprayFuelNames[i];
       }
-      sprayData.latent[i] = sprayData.ref_latent[i];
+      m_sprayData->latent[i] = m_sprayData->ref_latent[i];
     }
   }
 
@@ -134,30 +140,25 @@ SprayParticleContainer::readSprayParams(
   //
   // Set if spray ascii files should be written
   //
-  pp.query("write_ascii_files", write_spray_ascii_files);
+  pp.query("write_ascii_files", m_writeASCIIFiles);
   //
   // Set if gas phase spray source term should be written
   //
-  pp.query("plot_src", plot_spray_src);
+  pp.query("plot_src", m_plotSpraySrc);
   //
   // Used in initData() on startup to read in a file of particles.
   //
-  pp.query("init_file", init_file);
-  //
-  // Used in initData() on startup to set the particle field using the
-  // SprayParticlesInitInsert.cpp problem specific function
-  //
-  pp.query("init_function", init_function);
+  pp.query("init_file", m_initFile);
 #ifdef AMREX_USE_EB
   //
   // Spray source terms are only added to cells with a volume fraction higher
   // than this value
   //
-  pp.query("min_eb_vfrac", sprayData.min_eb_vfrac);
+  pp.query("min_eb_vfrac", m_sprayData->min_eb_vfrac);
 #endif
 
-  sprayData.num_ppp = parcel_size;
-  sprayData.ref_T = spray_ref_T;
+  m_sprayData->num_ppp = parcel_size;
+  m_sprayData->ref_T = spray_ref_T;
 
   // List of known derived spray quantities
   std::vector<std::string> derive_names = {
@@ -201,7 +202,7 @@ SprayParticleContainer::readSprayParams(
 }
 
 void
-SprayParticleContainer::spraySetup(SprayData& sprayData, const Real* body_force)
+SprayParticleContainer::spraySetup(const Real* body_force)
 {
 #if NUM_SPECIES > 1
   Vector<std::string> spec_names;
@@ -211,34 +212,61 @@ SprayParticleContainer::spraySetup(SprayData& sprayData, const Real* body_force)
     for (int ns = 0; ns < NUM_SPECIES; ++ns) {
       std::string gas_spec = spec_names[ns];
       if (gas_spec == m_sprayFuelNames[i]) {
-        sprayData.indx[i] = ns;
+        m_sprayData->indx[i] = ns;
       }
       if (gas_spec == m_sprayDepNames[i]) {
-        sprayData.dep_indx[i] = ns;
+        m_sprayData->dep_indx[i] = ns;
       }
     }
-    if (sprayData.indx[i] < 0) {
+    if (m_sprayData->indx[i] < 0) {
       Abort("Fuel " + m_sprayFuelNames[i] + " not found in species list");
     }
-    if (sprayData.dep_indx[i] < 0) {
+    if (m_sprayData->dep_indx[i] < 0) {
       Abort("Fuel " + m_sprayDepNames[i] + " not found in species list");
     }
   }
 #else
-  sprayData.indx[0] = 0;
-  sprayData.dep_indx[0] = 0;
+  m_sprayData->indx[0] = 0;
+  m_sprayData->dep_indx[0] = 0;
 #endif
   SprayUnits SPU;
   Vector<Real> fuelEnth(NUM_SPECIES);
   auto eos = pele::physics::PhysicsType::eos();
-  eos.T2Hi(sprayData.ref_T, fuelEnth.data());
+  eos.T2Hi(m_sprayData->ref_T, fuelEnth.data());
   for (int ns = 0; ns < SPRAY_FUEL_NUM; ++ns) {
-    const int fspec = sprayData.indx[ns];
-    sprayData.latent[ns] -= fuelEnth[fspec] * SPU.eng_conv;
+    const int fspec = m_sprayData->indx[ns];
+    m_sprayData->latent[ns] -= fuelEnth[fspec] * SPU.eng_conv;
   }
   for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-    sprayData.body_force[dir] = body_force[dir];
+    m_sprayData->body_force[dir] = body_force[dir];
   }
+  Gpu::copy(Gpu::hostToDevice, m_sprayData, m_sprayData + 1, d_sprayData);
   Gpu::streamSynchronize();
   ParallelDescriptor::Barrier();
+}
+
+void SprayParticleContainer::SprayInitialize(
+#ifdef PELELM_USE_SPRAY
+    ProbParm const& prob_parm,
+#else
+    ProbParmHost const& prob_parm,
+    ProbParmDevice const& prob_parm_d,
+#endif
+    const std::string& restart_dir)
+{
+  bool init_sprays = false;
+  if (restart_dir.empty() && spray_init_file.empty()) {
+    init_sprays = true;
+  }
+  InitSprayParticles(init_part, prob_parm
+#ifndef PELELM_USE_SPRAY
+                     , prob_parm_d
+#endif
+                     );
+  if (!spray_init_file.empty()) {
+    InitFromAsciiFile(spray_init_file, NSR_SPR);
+  } else if (!restart_dir.empty()) {
+    Restart(restart_dir, "particles");
+  }
+  PostInitRestart(restart_dir);
 }

--- a/Source/PP_Spray/SpraySetup.cpp
+++ b/Source/PP_Spray/SpraySetup.cpp
@@ -108,9 +108,11 @@ SprayParticleContainer::readSprayParams(int& particle_verbose)
     getInpVal(m_sprayData->cp.data(), pp, fuel_names.data(), "cp");
     getInpVal(m_sprayData->ref_latent.data(), pp, fuel_names.data(), "latent");
 
-    getInpCoef(m_sprayData->lambda_coef.data(), pp, fuel_names.data(), "lambda");
+    getInpCoef(
+      m_sprayData->lambda_coef.data(), pp, fuel_names.data(), "lambda");
     getInpCoef(m_sprayData->psat_coef.data(), pp, fuel_names.data(), "psat");
-    getInpCoef(m_sprayData->rho_coef.data(), pp, fuel_names.data(), "rho", true);
+    getInpCoef(
+      m_sprayData->rho_coef.data(), pp, fuel_names.data(), "rho", true);
     getInpCoef(m_sprayData->mu_coef.data(), pp, fuel_names.data(), "mu");
     for (int i = 0; i < nfuel; ++i) {
       m_sprayFuelNames[i] = fuel_names[i];
@@ -245,24 +247,27 @@ SprayParticleContainer::spraySetup(const Real* body_force)
   ParallelDescriptor::Barrier();
 }
 
-void SprayParticleContainer::SprayInitialize(
+void
+SprayParticleContainer::SprayInitialize(
 #ifdef PELELM_USE_SPRAY
-    ProbParm const& prob_parm,
+  ProbParm const& prob_parm,
 #else
-    ProbParmHost const& prob_parm,
-    ProbParmDevice const& prob_parm_d,
+  ProbParmHost const& prob_parm,
+  ProbParmDevice const& prob_parm_d,
 #endif
-    const std::string& restart_dir)
+  const std::string& restart_dir)
 {
   bool init_sprays = false;
   if (restart_dir.empty() && spray_init_file.empty()) {
     init_sprays = true;
   }
-  InitSprayParticles(init_part, prob_parm
+  InitSprayParticles(
+    init_part, prob_parm
 #ifndef PELELM_USE_SPRAY
-                     , prob_parm_d
+    ,
+    prob_parm_d
 #endif
-                     );
+  );
   if (!spray_init_file.empty()) {
     InitFromAsciiFile(spray_init_file, NSR_SPR);
   } else if (!restart_dir.empty()) {

--- a/Source/PP_Spray/SpraySetup.cpp
+++ b/Source/PP_Spray/SpraySetup.cpp
@@ -142,15 +142,15 @@ SprayParticleContainer::readSprayParams(int& particle_verbose)
   //
   // Set if spray ascii files should be written
   //
-  pp.query("write_ascii_files", m_writeASCIIFiles);
+  pp.query("write_ascii_files", write_ascii_files);
   //
   // Set if gas phase spray source term should be written
   //
-  pp.query("plot_src", m_plotSpraySrc);
+  pp.query("plot_src", plot_spray_src);
   //
   // Used in initData() on startup to read in a file of particles.
   //
-  pp.query("init_file", m_initFile);
+  pp.query("init_file", spray_init_file);
 #ifdef AMREX_USE_EB
   //
   // Spray source terms are only added to cells with a volume fraction higher
@@ -262,7 +262,7 @@ SprayParticleContainer::SprayInitialize(
     init_sprays = true;
   }
   InitSprayParticles(
-    init_part, prob_parm
+    init_sprays, prob_parm
 #ifndef PELELM_USE_SPRAY
     ,
     prob_parm_d


### PR DESCRIPTION
Moved much of spray data from local data in the Pele class or local member data in the spray class, to be static member data in the spray class. Eliminates the much of the variables that are specified in empty namespaces in the Pele spray routines. 